### PR TITLE
fix(credential handling): show better error messages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/yolo
+    docker:
+      - image: circleci/python:3.6.1
+    steps:
+      - checkout
+
+      - run:
+          name: Install build/test dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install python-dev python3-dev
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install tox
+      - run:
+          name: Run tox
+          command: |
+            . venv/bin/activate
+            tox


### PR DESCRIPTION
If credentials are invalid or missing (either using `yolo login` or by
setting environment variables), show more helpful error messages to
give the user hints about how to fix the problem.

Fixes #5.
