### PR TITLE
fix(error handling): propagate more friendly CloudFormation errors

### DIFF
--- a/yolo/client.py
+++ b/yolo/client.py
@@ -34,6 +34,7 @@ except ImportError:
 
 from yolo.cloudformation import CloudFormation
 from yolo import const
+import yolo.exceptions
 from yolo.exceptions import NoInfrastructureError
 from yolo.exceptions import StackDoesNotExist
 from yolo.exceptions import YoloError
@@ -815,11 +816,15 @@ class YoloClient(object):
             for k, v in templates_cfg['params'].items()
         ]
 
-        self._create_or_update_stack(
-            cf_client, stack_name, master_url, stack_params, tags,
-            dry_run=dry_run, recreate=recreate, asynchronous=asynchronous,
-            force=force,
-        )
+        try:
+            self._create_or_update_stack(
+                cf_client, stack_name, master_url, stack_params, tags,
+                dry_run=dry_run, recreate=recreate, asynchronous=asynchronous,
+                force=force,
+            )
+        except yolo.exceptions.CloudFormationError as err:
+            # Re-raise it as a friendly error message:
+            raise YoloError(str(err))
 
     def deploy_baseline_infra(self, account, dry_run=False,
                               asynchronous=False):

--- a/yolo/exceptions.py
+++ b/yolo/exceptions.py
@@ -1,5 +1,5 @@
 class YoloError(Exception):
-    pass
+    """Errors meant to be displayed to the user in a friendly way."""
 
 
 class NoInfrastructureError(YoloError):
@@ -12,3 +12,7 @@ class StackDoesNotExist(Exception):
 
 class ResourceNotFound(Exception):
     pass
+
+
+class CloudFormationError(Exception):
+    """Errors related to CloudFormation resource management."""

--- a/yolo/waiter.py
+++ b/yolo/waiter.py
@@ -4,6 +4,8 @@ import time
 
 from botocore.exceptions import ClientError
 
+import yolo.exceptions
+
 
 class VerboseCloudFormationWaiter(object):
     """Custom waiter that prints on progress to standard outpout.
@@ -71,5 +73,8 @@ class VerboseCloudFormationWaiter(object):
             else:
                 # This means we have reached an unexpected state, let's raise
                 # an exception.
-                raise RuntimeError(
-                    'The stack reached an unexpected state: {}'.format(stack_status))
+                raise yolo.exceptions.CloudFormationError(
+                    'The stack reached an unexpected state: {}'.format(
+                        stack_status
+                    )
+                )


### PR DESCRIPTION
In the case of a rollback to a stack update (which can happen while
making/testing changes to CloudFormation), we should display a simple
message instead of a stack trace. In other words, this is not an
"exceptional" case, but rather a known and valid one.

Fixes #6.