### PR TITLE
fix(s3 artifacts): protect all s3 artifacts with SSE/private ACL

### DIFF
--- a/yolo/client.py
+++ b/yolo/client.py
@@ -810,7 +810,11 @@ class YoloClient(object):
             cf_file_full_path = os.path.join(full_templates_dir, cf_file)
             bucket_key = '{}/{}'.format(bucket_folder_prefix, cf_file)
             print('uploading s3://{}/{}...'.format(bucket.name, bucket_key))
-            bucket.upload_file(Filename=cf_file_full_path, Key=bucket_key)
+            bucket.upload_file(
+                Filename=cf_file_full_path,
+                Key=bucket_key,
+                ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
+            )
 
         cf_client = self.faws_client.boto3_session(acct_num).client(
             'cloudformation',

--- a/yolo/const.py
+++ b/yolo/const.py
@@ -49,3 +49,4 @@ BUCKET_FOLDER_PREFIXES = {
 # Environment variable name for storing SSM config version/path.
 # This tells deployed applications where to find config/secrets in SSM.
 SSM_CONFIG_VERSION = 'SSM_CONFIG_VERSION'
+S3_UPLOAD_EXTRA_ARGS = dict(ACL='private', ServerSideEncryption='AES256')

--- a/yolo/services/lambda_service.py
+++ b/yolo/services/lambda_service.py
@@ -134,10 +134,7 @@ class LambdaService(yolo.services.BaseService):
             Filename=lambda_fn_path,
             Key=os.path.join(bucket_folder_prefix, 'lambda_function.zip'),
             Callback=utils.S3UploadProgress(lambda_fn_path),
-            ExtraArgs={
-                'ACL': 'private',
-                'ServerSideEncryption': 'AES256',
-            },
+            ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
         )
         # if apig, upload service.working_dir + 'swagger.yml' to 'swagger.yaml'
         if service_cfg['type'] == (
@@ -151,6 +148,7 @@ class LambdaService(yolo.services.BaseService):
             bucket.upload_file(
                 Filename=swagger_yaml_path,
                 Key=os.path.join(bucket_folder_prefix, const.SWAGGER_YAML),
+                ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
             )
 
         bucket.upload_fileobj(
@@ -159,6 +157,7 @@ class LambdaService(yolo.services.BaseService):
             # system. This allows for later deployments to just pick the file
             # up (or ignore it explicitly) by convention.
             Key=os.path.join(bucket_folder_prefix, const.YOLO_YAML),
+            ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
         )
 
     def deploy_local_version(self, service, stage):

--- a/yolo/services/s3_service.py
+++ b/yolo/services/s3_service.py
@@ -124,6 +124,7 @@ class S3Service(yolo.services.BaseService):
             # system. This allows for later deployments to just pick the file
             # up (or ignore it explicitly) by convention.
             Key=os.path.join(bucket_folder_prefix, const.YOLO_YAML),
+            ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
         )
 
         # TODO(larsbutler): check output and errors from the sp call


### PR DESCRIPTION
There generally shouldn't be any secrets in these files, but just in
case, encrypting and making everything private by default is a good
idea. (The Private ACL setting also protects against cases where the S3
bucket is accidentally given a public-read ACL, etc.)

This is a follow-up to #11.