### PR TITLE
Add CloudFormation stack termination protection

### DIFF
--- a/yolo/client.py
+++ b/yolo/client.py
@@ -844,42 +844,6 @@ class YoloClient(object):
             # Re-raise it as a friendly error message:
             raise YoloError(str(err))
 
-    def deploy_baseline_infra(self, account, dry_run=False,
-                              asynchronous=False):
-        """Deploy baseline infrastructure for a given account."""
-        self.set_up_yolofile_context(account=account)
-        self._yolo_file = self.yolo_file.render(**self.context)
-
-        bucket = self._ensure_bucket(
-            self.context.account.account_number,
-            self.yolo_file.templates['account']['region'],
-            self.app_bucket_name
-        )
-
-        bucket_folder_prefix = (
-            const.BUCKET_FOLDER_PREFIXES['account-templates'].format(
-                timestamp=self.now_timestamp
-            )
-        )
-
-        tags = [
-            const.YOLO_STACK_TAGS['created-with-yolo-version'],
-            # Always protect baseline infra stacks:
-            const.YOLO_STACK_TAGS['protected'],
-        ]
-
-        self._deploy_stack(
-            self.account_stack_name,
-            self.yolo_file.templates['account'],
-            bucket_folder_prefix,
-            bucket,
-            self.context.account.account_number,
-            self.yolo_file.templates['account']['region'],
-            tags,
-            dry_run=dry_run,
-            asynchronous=asynchronous,
-        )
-
     def status(self, stage=None):
         self.set_up_yolofile_context()
         self._yolo_file = self.yolo_file.render(**self.context)

--- a/yolo/script.py
+++ b/yolo/script.py
@@ -190,15 +190,6 @@ def list_accounts():
         'Not allowed on account-level stacks.'
     ),
 )
-@click.option(
-    '--force',
-    is_flag=True,
-    default=False,
-    help=(
-        'DANGER ZONE: Use this flag to force stack re-creation on protected '
-        'stages.'
-    ),
-)
 @handle_yolo_errors
 def deploy_infra(yolo_file=None, **kwargs):
     """Deploy infrastructure from templates."""
@@ -474,15 +465,6 @@ def list_lambda_builds(yolo_file=None, **kwargs):
     help=(
         'DANGER ZONE: Tear down and re-deploy infrastructure from scratch. '
         'Not allowed on account-level stacks.'
-    ),
-)
-@click.option(
-    '--force',
-    is_flag=True,
-    default=False,
-    help=(
-        'DANGER ZONE: Use this flag to force stack re-creation on protected '
-        'stages.'
     ),
 )
 @handle_yolo_errors


### PR DESCRIPTION
(This is a work in progress. Some feedback is needed.)

Summary:
- use the "hard" stack protection provided by the [new CloudFormation feature](https://aws.amazon.com/about-aws/whats-new/2017/09/aws-cloudformation-now-provides-stack-termination-protection/)
- if a stack is marked as protected but doesn't yet have the CF termination protection enabled, apply it automatically (and implicitly)
- remove the `--force` option from `yolo deploy-infra`; with the new stack protection, I don't think it make sense to so easily bypass the protection

Fixes #13.