### PR TITLE
feat(params): Inherit default parameters

### DIFF
--- a/example.yolo.yaml
+++ b/example.yolo.yaml
@@ -148,13 +148,17 @@ services:
           - name: 'private_key'
             multiline: true
         # If a stage is not explicitly declared here in this section,
-        # parameters from the `default` stage will be used.
+        # parameters from the `default` stage will be used. The parameters
+        # here are inherited by all other stages, so if they don't exist in
+        # stage-specific sections, they will be available as defined here.
         default:
           - name: 'db_username'
             value: 'dev_admin'
           - name: 'db_password'
           - name: 'private_key'
             multiline: true
+          - name: 'stage'
+            value: '{{ stage.name }}'
   MyUIService:
     type: 's3'
     # Destination bucket where published files are to be stored:

--- a/yolo/client.py
+++ b/yolo/client.py
@@ -1415,12 +1415,18 @@ class YoloClient(object):
         self._yolo_file = self.yolo_file.render(**self.context)
 
         service_cfg = self.yolo_file.services[service]
-        # Get stage specific parameter config, or get the default if this is
-        # an ad-hoc/custom stage.
-        parameters = service_cfg['parameters']['stages'].get(
-            # TODO(larsbutler): handle index errors if no default defined.
-            stage, service_cfg['parameters']['stages']['default']
-        )
+        # Get the default parameters first, if available.
+        parameters = service_cfg['parameters']['stages'].get('default', [])
+        # Convert the list to a dict, so that it can be easily overridden by
+        # stage-specific parameters.
+        parameters_dict = {p['name']: p for p in parameters}
+        # Get the stage-specific parameters.
+        stage_parameters = service_cfg['parameters']['stages'].get(stage, [])
+        stage_parameters_dict = {p['name']: p for p in stage_parameters}
+        # Override default parameters with any stage-specific ones.
+        parameters_dict.update(stage_parameters_dict)
+        # Convert back to a list that we'll use going forward.
+        parameters = parameters_dict.values()
 
         if len(param) > 0:
             # Only set specific params.


### PR DESCRIPTION
The goal of this PR is to reduce the verbosity/redundancy of the Yolo file, so you'll only have to specify parameters in stage-specific config sections that are different from the defaults.