### PR TITLE
Fixing issue with lambda only deployment pushes

### DIFF
--- a/yolo/services/lambda_service.py
+++ b/yolo/services/lambda_service.py
@@ -109,9 +109,6 @@ class LambdaService(yolo.services.BaseService):
             os.path.abspath(service_cfg['build']['dist_dir']),
             'lambda_function.zip'
         )
-        swagger_yaml_path = service_cfg['deploy']['apigateway'][
-            'swagger_template'
-        ]
 
         bucket.upload_file(
             Filename=lambda_fn_path,
@@ -123,10 +120,12 @@ class LambdaService(yolo.services.BaseService):
         if service_cfg['type'] == (
                 yolo_file.YoloFile.SERVICE_TYPE_LAMBDA_APIGATEWAY
         ):
+            gateway_config = service_cfg['deploy']['apigateway']
+
             # grab the rendered swagger file from the working_dir
             # and upload it to the S3 bucket
             bucket.upload_file(
-                Filename=swagger_yaml_path,
+                Filename=gateway_config['swagger_template'],
                 Key=os.path.join(bucket_folder_prefix, const.SWAGGER_YAML),
                 ExtraArgs=const.S3_UPLOAD_EXTRA_ARGS,
             )


### PR DESCRIPTION
We ran into an issue where on yolo push for a lambda only deployment it was expected API Gateway configuration. Addressing this issue by moving it down into the conditional.