### PR TITLE
feat(aws-cli): Support AWS CLI credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Manage infrastructure and services on AWS for multiple accounts/stages.
 
 (Or, "yolo everything into prod.")
 
+[![Documentation Status](https://readthedocs.org/projects/yolocli/badge/?version=latest)](http://yolocli.readthedocs.io/en/latest/?badge=latest)
+
 ## Terminology
 
  * __Project:__ a collection of services, the code repository represents a project.
@@ -31,7 +33,7 @@ yolo login
  3. Deploy the baseline infrastructure:
 
 ```
-yolo deploy-baseline-infra --account testaccount
+yolo deploy-infra --account testaccount
 ```
 
  4. Define stage-level resources using a different CloudFormation template. There can be multiple stages within a single account (they will be deployed as separate CloudFormation stacks), and a stage represents an instance of your project (collection of services).
@@ -83,4 +85,5 @@ Commands:
   show-service           Show service configuration for a given stage.
   status                 Show infrastructure deployments status.
   upload-s3              DEPRECATED: Use `yolo push` instead.
+  use-profile            Make Yolo use an AWS CLI named profile.
 ```

--- a/example.yolo.yaml
+++ b/example.yolo.yaml
@@ -5,8 +5,12 @@ name: 'MyApplicationName'
 accounts:
   - name: 'mydev'
     account_number: '111222333444'
+    # The region where the base infrastructure and some Yolo-specific artifacts
+    # will be deployed.
+    default_region: 'us-west-2'
   - name: 'myprod'
     account_number: '555666777888'
+    default_region: 'us-west-2'
 
 templates:
   # Templates for account-specific infrastructure.
@@ -17,8 +21,6 @@ templates:
     path: 'cloudformation/account'
     params:
       AccountName: '{{ account.name }}'
-    # The region for this base infrastructure to be deployed.
-    region: 'us-west-2'
   # Templates for stage-specific infrastructure.
   stage:
     # Relative or absolute path to a directory containing CloudFormation

--- a/yolo/client.py
+++ b/yolo/client.py
@@ -40,6 +40,7 @@ import tabulate
 
 from yolo.cloudformation import CloudFormation
 from yolo import const
+from yolo.credentials.aws_cli import AWSCLICredentials
 import yolo.exceptions
 from yolo.exceptions import NoInfrastructureError
 from yolo.exceptions import StackDoesNotExist
@@ -94,6 +95,9 @@ class YoloClient(object):
         self._rax_username = None
         self._rax_api_key = None
 
+        # AWS CLI named profile
+        self._aws_profile_name = None
+
         self._version_hash = None
 
         # This will get populated when the ``yolo_file`` is read and the basic
@@ -131,6 +135,18 @@ class YoloClient(object):
         return self._rax_api_key
 
     @property
+    def aws_profile_name(self):
+        if self._aws_profile_name is None:
+            self._aws_profile_name = (
+                os.getenv(const.AWS_PROFILE_NAME) or
+                keyring.get_password(const.NAMESPACE, 'aws_profile_name')
+            )
+
+        # We can allow this value to be None, because in that case we'll
+        # fallback to FAWS credentials.
+        return self._aws_profile_name
+
+    @property
     def context(self):
         """Environment context for commands and template rendering."""
         if self._context is None:
@@ -148,9 +164,17 @@ class YoloClient(object):
     def faws_client(self):
         """Lazily instantiate a FAWS client."""
         if self._faws_client is None:
-            self._faws_client = faws_client.FAWSClient(
-                self.rax_username, self.rax_api_key
-            )
+            # NOTE(szilveszter): This is just a quick hack, because I wanted
+            # to avoid refactoring everything. If this ends up being a good
+            # approach, I'm happy to do the work.
+            # If we have a profile stored, let's use it instead of going to
+            # FAWS first.
+            if self.aws_profile_name:
+                self._faws_client = AWSCLICredentials(self.aws_profile_name)
+            else:
+                self._faws_client = faws_client.FAWSClient(
+                    self.rax_username, self.rax_api_key
+                )
 
         return self._faws_client
 
@@ -746,10 +770,12 @@ class YoloClient(object):
 
     def show_config(self):
         print('Rackspace user: {}'.format(self.rax_username))
+        print('AWS CLI named profile: {}'.format(self.aws_profile_name))
 
     def clear_config(self):
         keyring.delete_password(const.NAMESPACE, 'rackspace_username')
         keyring.delete_password(const.NAMESPACE, 'rackspace_api_key')
+        keyring.delete_password(const.NAMESPACE, 'aws_profile_name')
 
     def login(self):
         # Get RACKSPACE_USERNAME and RACKSPACE_API_KEY envvars
@@ -769,6 +795,19 @@ class YoloClient(object):
             const.NAMESPACE, 'rackspace_api_key', self.rax_api_key
         )
         print('login successful!')
+
+    def use_profile(self, profile_name):
+        if profile_name is None:
+            # NOTE(szilveszter): At some point we could read the profiles from
+            # the credentials files, and we could ask the user to choose one.
+            raise YoloError(
+                "Please specify a profile with the '--profile-name' option."
+            )
+
+        self._aws_profile_name = profile_name
+        keyring.set_password(
+            const.NAMESPACE, 'aws_profile_name', self.aws_profile_name
+        )
 
     def list_accounts(self):
         accounts = self.faws_client.list_aws_accounts()

--- a/yolo/const.py
+++ b/yolo/const.py
@@ -18,6 +18,7 @@ YOLO_YAML = 'yolo.yaml'
 DEFAULT_FILENAMES = [YOLO_YAML, 'yolo.yml']
 RACKSPACE_USERNAME = 'RACKSPACE_USERNAME'
 RACKSPACE_API_KEY = 'RACKSPACE_API_KEY'
+AWS_PROFILE_NAME = 'AWS_PROFILE_NAME'
 NAMESPACE = 'yolo'
 SWAGGER_YAML = 'swagger.yaml'
 # FAWS account service level IDs and their respective human-readable labels.

--- a/yolo/credentials/aws_cli.py
+++ b/yolo/credentials/aws_cli.py
@@ -1,0 +1,24 @@
+import boto3
+
+
+class AWSCLICredentials(object):
+
+    def __init__(self, profile_name):
+        self.profile_name = profile_name
+        self.session = boto3.session.Session(profile_name=profile_name)
+
+    def get_aws_account_credentials(self, aws_account_number, duration=3600):
+        # We'll just ignore all arguments, because credentials are already
+        # available, we just need to get them from the session.
+        creds = self.session.get_credentials()
+        janus_style_creds = {
+            'accessKeyId': creds.access_key,
+            'secretAccessKey': creds.secret_key,
+        }
+        if creds.token:
+            janus_style_creds['sessionToken'] = creds.token
+
+        return janus_style_creds
+
+    def aws_client(self, acct_num, aws_service, region_name=None, **kwargs):
+        return self.session.client(aws_service, region_name=region_name, **kwargs)

--- a/yolo/script.py
+++ b/yolo/script.py
@@ -153,6 +153,14 @@ def login():
     client.YoloClient().login()
 
 
+@cli.command(name='use-profile')
+@click.option('--profile-name', metavar='PROFILE_NAME')
+@handle_yolo_errors
+def use_profile(profile_name):
+    """Make Yolo use an AWS CLI named profile."""
+    client.YoloClient().use_profile(profile_name)
+
+
 @cli.command(name='list-accounts')
 @handle_yolo_errors
 def list_accounts():


### PR DESCRIPTION
This is mostly a quick hack to make this work, once we're happy with this approach, and it seems bug free, I'm happy to do some refactoring.

The idea is that you just add your credentials to the AWS CLI credentials file (`~/.aws/credentials`) into a named profile (or even just `default`), and then run:

    $ yolo use-profile --profile-name default

Once you set this, it will take precedence over any Rackspace Cloud accounts set.