### PR TITLE
feat(client): add --copy-from-stage option to `yolo put-parameters`

### DIFF
--- a/yolo/script.py
+++ b/yolo/script.py
@@ -346,6 +346,16 @@ def show_parameters(yolo_file=None, **kwargs):
         'times.'
     ),
 )
+@click.option(
+    '--copy-from-stage',
+    '-c',
+    metavar='STAGE',
+    required=False,
+    help=(
+        'If possible, copy parameters from this stage. This can be used in '
+        'conjunction with `--param` to copy explicit sets of parameters.'
+    )
+)
 @yolo_file_option()
 @handle_yolo_errors
 def put_parameters(yolo_file=None, **kwargs):


### PR DESCRIPTION
Add the option to copy parameters from an another stage. This is useful
for personal dev stages where the configuration is the same as or
similar to another base stage (such as "dev", for example).