### PR TITLE
setup.py: pin botocore to 1.7.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ config = dict(
     install_requires=[
         'awscli',
         'boto3',
-        'botocore',
+        'botocore>=1.7.18',
         'click',
         'docker',
         'jinja2',


### PR DESCRIPTION
This is the minimum version required to be able to use stack termination
protection.