### PR TITLE
Allow templates section to be empty

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -109,6 +109,10 @@ The templates section has two sub-sections: ``account`` and ``stage``:
 - ``params`` are input parameters to the respective template. If your templates
   do not require any parameters, enter ``params: {}``.
 
+If you don't use any CloudFormation templates to stand up your infrastucture,
+you still have to define the ``templates`` section, but you can leave it empty:
+``templates: {}``.
+
 .. _yolo_yaml_services:
 
 ``services`` section

--- a/yolo/yolo_file.py
+++ b/yolo/yolo_file.py
@@ -56,7 +56,7 @@ class YoloFile(object):
     })
     TEMPLATES_SCHEMA = volup.Schema({
         volup.Optional('account'): ACCOUNT_TEMPLATE_SCHEMA,
-        volup.Required('stage'): STAGE_TEMPLATE_SCHEMA,
+        volup.Optional('stage'): STAGE_TEMPLATE_SCHEMA,
     })
     # 'stages' section
     STAGES_SCHEMA = volup.Schema({


### PR DESCRIPTION
This way we can still use many features of Yolo, that don't depend on CloudFormation (e.g. Lambda package builds, or parameter management).