### PR TITLE
fix(parameters): Fix buffering issue for multiline input edge case

### DIFF
--- a/yolo/client.py
+++ b/yolo/client.py
@@ -1462,6 +1462,7 @@ class YoloClient(object):
                         '(ctrl+d when finished):'.format(param_name),
                         end=''
                     )
+                    sys.stdout.flush()
                     param_value = sys.stdin.read()
                 else:
                     # Otherwise, just get a single line entry using non-echoing


### PR DESCRIPTION
Whenever I issue a `put-parameters` with `--use-defaults`, the command seems to hang, but the problem is that it's just waiting for the multiline input, even though the text asking for it does not appear on the screen.