### PR TITLE
feat(showOutputs): add output key getting option and formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ ENV/
 
 # Visual Studio Code
 .vscode/
+
+#pyCharm code
+.idea/

--- a/yolo/client.py
+++ b/yolo/client.py
@@ -1498,7 +1498,7 @@ class YoloClient(object):
         )
         lambda_svc.show(service, stage)
 
-    def show_outputs(self, stage=None, account=None):
+    def show_outputs(self, stage=None, account=None, key=None, format=None):
         with_stage = stage is not None
         with_account = account is not None
 
@@ -1521,10 +1521,20 @@ class YoloClient(object):
                 self.context.account.account_number,
                 self.context.account.default_region,
             )
-        table = [('Name', 'Value')]
-        for output in sorted(outputs.items()):
-            table.append(output)
-        print(tabulate.tabulate(table, headers='firstrow'))
+
+        if len(key) > 0:
+            # Drop everything except for the specified keys.
+            outputs = {k: outputs[k] for k in key}
+        if format == 'json':
+            print(json.dumps(outputs, sort_keys=True, indent=2))
+        elif format == 'table':
+            table = [('Name', 'Value')]
+            for output in sorted(outputs.items()):
+                table.append(output)
+            print(tabulate.tabulate(table, headers='firstrow'))
+        elif format == 'value':
+            for output in outputs.values():
+                print(output)
 
 
 def get_username():

--- a/yolo/script.py
+++ b/yolo/script.py
@@ -71,6 +71,38 @@ def stage_option(**attrs):
     return option
 
 
+def key_option(**attrs):
+    """A --key option for commands."""
+    kwargs = dict(
+        metavar='KEY',
+        required=False,
+        help='Output key name.'
+    )
+    kwargs.update(attrs)
+    option = click.option(
+        '--key', multiple=True,
+        **kwargs
+    )
+    return option
+
+
+def format_option(**attrs):
+    """A --format option for commands."""
+    kwargs = dict(
+        metavar='FORMAT',
+        required=False,
+        default='table',
+        type=click.Choice(['table', 'json', 'value']),
+        help='Output Format Type name.'
+    )
+    kwargs.update(attrs)
+    option = click.option(
+        '--format',
+        **kwargs
+    )
+    return option
+
+
 def service_option(**attrs):
     """A --service option for commands."""
     kwargs = dict(
@@ -384,6 +416,8 @@ def show_service(yolo_file=None, **kwargs):
 @cli.command('show-outputs')
 @account_option(required=False)
 @stage_option(required=False)
+@key_option(required=False)
+@format_option(required=False)
 @yolo_file_option()
 @handle_yolo_errors
 def show_outputs(yolo_file=None, **kwargs):


### PR DESCRIPTION
solution for https://github.com/rackerlabs/yolo/issues/41

2 features:
 - extra formatting options ( json, table, value -> table is the default one) 
 - get only 1 or multiple output keys

formatting
```bash
yolo show-outputs --account devAccount                  # table output with all keys
yolo show-outputs --account devAccount --format json    # json output with all keys
yolo show-outputs --account devAccount --format value   # value output with all values
```
key or keys
```bash
yolo show-outputs --account devAccount --key myKey1                  # table output with only myKey1
yolo show-outputs --account devAccount --key myKey1 --key myKey2     # table output with myKey1 and myKey2
```