### PR TITLE
Capture non-zero exit status from `yolo run`

### DIFF
--- a/yolo/client.py
+++ b/yolo/client.py
@@ -1320,7 +1320,11 @@ class YoloClient(object):
         sp_args.extend(posargs)
         sp = subprocess.Popen(sp_args, env=sp_env)
         # TODO(larsbutler): Get stdout and stderr
-        sp.wait()
+        exit_status = sp.wait()
+        if not exit_status == 0:
+            raise YoloError(
+                'Command exited with non-zero ({}) status'.format(exit_status)
+            )
 
     def show_parameters(self, service, stage):
         params = self._get_ssm_parameters(service, stage)

--- a/yolo/script.py
+++ b/yolo/script.py
@@ -344,6 +344,7 @@ def shell(yolo_file=None, **kwargs):
     required=False,
     nargs=-1,
 )
+@handle_yolo_errors
 def run(yolo_file=None, **kwargs):
     """Run a script with AWS account credentials."""
     account = kwargs['account']


### PR DESCRIPTION
If a command returns non-zero, display an error with the exit status and
raise an exception. This will help prevent scripted commands from
failing silenty.