### PR TITLE
Add `ensure-parameters` command

### DIFF
--- a/yolo/script.py
+++ b/yolo/script.py
@@ -404,6 +404,16 @@ def put_parameters(yolo_file=None, **kwargs):
     client.YoloClient(yolo_file=yolo_file).put_parameters(**kwargs)
 
 
+@cli.command(name='ensure-parameters')
+@service_option(required=True)
+@stage_option(required=True)
+@yolo_file_option()
+@handle_yolo_errors
+def ensure_parameters(yolo_file=None, **kwargs):
+    """Ensure that all required parameters are defined in SSM."""
+    client.YoloClient(yolo_file=yolo_file).ensure_parameters(**kwargs)
+
+
 @cli.command(name='show-service')
 @service_option(required=True)
 @stage_option(required=True)


### PR DESCRIPTION
`deploy-lambda` already performs similar validation (to ensure all
necessary config is available for a deployment), but this functionality
is useful if you want to perform this sanity check independently of a
deployment (or if you're doing your deployment using something other
than `yolo deploy-lamdba`).

If all required parameters (defined in the yolo.yaml) are defined in SSM:

```
$ yolo ensure-parameters --service my-service --stage prod
All required parameters are stored in SSM
```

If not:

```
$ yolo ensure-parameters --service my-service --stage prod
Error: The following parameters were not found in SSM for "--service my-service" and "--stage prod":
	- missing-param
        - another-missing-param
        - foo
To fix this, try running `yolo put-parameters --service my-service --stage prod`.
```