### PR TITLE
Use docker volume mounts (instead of bind mounts)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 awscli
 boto3
 click
-docker==2.5.1
+docker==3.4.0
 jinja2
 keyring==8.7.0
 keyrings.alt

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ config = dict(
         'boto3',
         'botocore>=1.7.18',
         'click',
-        'docker==2.5.1',
+        'docker==3.4.0',
         'jinja2',
         'keyring==8.7.0',
         'keyrings.alt',

--- a/yolo/build.py
+++ b/yolo/build.py
@@ -96,33 +96,3 @@ def export_container_files(container, src_path, dst_path):
 
     with tarfile.open(fileobj=stream, mode='r') as tar:
         tar.extractall(path=dst_path)
-
-
-def export_build_cache(container, dst_path):
-    # Copy build_cache from a container to a local directory.
-    stream = io.BytesIO()
-    tar_generator, _ = container.get_archive('/build_cache/.',
-                                             chunk_size=1024*1024*2)
-
-    for bytes in tar_generator:
-        stream.write(bytes)
-    else:
-        stream.seek(0)
-
-    with tarfile.open(fileobj=stream, mode='r') as tar:
-        tar.extractall(path=dst_path)
-
-
-def export_lambda_package(container, dst_path):
-    # Copy lambda zip from a container to a local directory.
-    stream = io.BytesIO()
-    tar_generator, _ = container.get_archive('/dist/lambda_function.zip',
-                                             chunk_size=1024*1024*2)
-
-    for bytes in tar_generator:
-        stream.write(bytes)
-    else:
-        stream.seek(0)
-
-    with tarfile.open(fileobj=stream, mode='r') as tar:
-        tar.extractall(path=dst_path)

--- a/yolo/build.py
+++ b/yolo/build.py
@@ -1,4 +1,7 @@
+import io
 import logging
+import os
+import tarfile
 import time
 
 LOG = logging.getLogger(__name__)
@@ -26,10 +29,11 @@ def wait_for_container_to_finish(container):
     return exit_code
 
 
-def remove_container(container):
+def remove_container(container, **kwargs):
     try:
         LOG.warning('Removing build container')
-        container.remove()
+        LOG.warning('kwargs is %s', kwargs)
+        container.remove(**kwargs)
     except Exception:
         # We just log an error and swallow the exception, because this happens
         # often on CircleCI.
@@ -37,3 +41,88 @@ def remove_container(container):
             "Could not remove container, please remove it manually (ID: %s)",
             container.short_id,
         )
+
+
+def put_files(container, src_dir, path, single_file_name=None):
+    stream = io.BytesIO()
+
+    with tarfile.open(fileobj=stream, mode='w') as tar:
+        if single_file_name:
+            arcname = single_file_name
+        else:
+            arcname = "/"
+        tar.add(src_dir, arcname=arcname)
+    stream.seek(0)
+    container.put_archive(data=stream, path=path)
+
+
+def create_build_volume_container(docker_client,
+                                  image="alpine:3.6",
+                                  working_dir=None,
+                                  dependencies_path=None,
+                                  dist_dir=None,
+                                  build_cache_dir=None):
+    docker_client.images.pull(image)
+    working_dir_volume = docker_client.volumes.create()
+    dependencies_volume = docker_client.volumes.create()
+    dist_dir_volume = docker_client.volumes.create()
+    build_cache_volume = docker_client.volumes.create()
+    volume_container = docker_client.containers.create(
+                 image, "/bin/true",
+                 volumes=[
+                           "{}:/src".format(working_dir_volume.name),
+                           "{}:/dependencies".format(dependencies_volume.name),
+                           "{}:/dist".format(dist_dir_volume.name),
+                           "{}:/build_cache".format(build_cache_volume.name)
+                         ])
+    put_files(volume_container, working_dir, "/src")
+    put_files(volume_container, dependencies_path, "/dependencies",
+              single_file_name="requirements.txt")
+    if os.path.isdir(build_cache_dir):
+        # only copy build cache if it exists.
+        put_files(volume_container, build_cache_dir, "/build_cache")
+    return volume_container
+
+
+def export_container_files(container, src_path, dst_path):
+    # Copy build_cache from a container to a local directory.
+    stream = io.BytesIO()
+    tar_generator, _ = container.get_archive(src_path)
+
+    for bytes in tar_generator:
+        stream.write(bytes)
+    else:
+        stream.seek(0)
+
+    with tarfile.open(fileobj=stream, mode='r') as tar:
+        tar.extractall(path=dst_path)
+
+
+def export_build_cache(container, dst_path):
+    # Copy build_cache from a container to a local directory.
+    stream = io.BytesIO()
+    tar_generator, _ = container.get_archive('/build_cache/.',
+                                             chunk_size=1024*1024*2)
+
+    for bytes in tar_generator:
+        stream.write(bytes)
+    else:
+        stream.seek(0)
+
+    with tarfile.open(fileobj=stream, mode='r') as tar:
+        tar.extractall(path=dst_path)
+
+
+def export_lambda_package(container, dst_path):
+    # Copy lambda zip from a container to a local directory.
+    stream = io.BytesIO()
+    tar_generator, _ = container.get_archive('/dist/lambda_function.zip',
+                                             chunk_size=1024*1024*2)
+
+    for bytes in tar_generator:
+        stream.write(bytes)
+    else:
+        stream.seek(0)
+
+    with tarfile.open(fileobj=stream, mode='r') as tar:
+        tar.extractall(path=dst_path)

--- a/yolo/services/lambda_service.py
+++ b/yolo/services/lambda_service.py
@@ -164,10 +164,18 @@ class LambdaService(yolo.services.BaseService):
         )
         exit_code = yolo.build.wait_for_container_to_finish(container)
         LOG.warning("exporting build cache...")
-        yolo.build.export_build_cache(build_volume_container, build_cache_dir)
+        yolo.build.export_container_files(
+            build_volume_container,
+            '/build_cache/.',
+            build_cache_dir
+        )
         LOG.warning("done exporting build cache.")
         LOG.warning("exporting lambda zip...")
-        yolo.build.export_lambda_package(build_volume_container, dist_dir)
+        yolo.build.export_container_files(
+            build_volume_container,
+            '/dist/lambda_function.zip',
+            dist_dir
+        )
         LOG.warning("done exporting lambda zip.")
         log_contents = container.logs(stdout=True, stderr=True)
         build_log.write(log_contents.decode('utf-8'))

--- a/yolo/services/lambda_service.py
+++ b/yolo/services/lambda_service.py
@@ -135,27 +135,46 @@ class LambdaService(yolo.services.BaseService):
             # No cache found; we must build deps.
             environment['REBUILD_DEPENDENCIES'] = '1'
 
+        build_volume_container = yolo.build.create_build_volume_container(
+            client,
+            working_dir=working_dir,
+            dependencies_path=dependencies_path,
+            dist_dir=dist_dir,
+            build_cache_dir=build_cache_dir)
+        LOG.warning(
+            "build_volume_container created (%s)",
+            build_volume_container.short_id
+        )
+
         container = client.containers.run(
             image=BUILD_IMAGE,
             # command='/bin/bash -c "./build_wheels.sh"',
             detach=True,
             environment=environment,
-            volumes={
-                working_dir: {'bind': '/src'},
-                dependencies_path: {'bind': '/dependencies/requirements.txt'},
-                dist_dir: {'bind': '/dist'},
-                build_cache_dir: {'bind': '/build_cache'},
-            },
+            volumes_from=[build_volume_container.id]
         )
+
+        LOG.warning("working_dir is %s", working_dir)
+        LOG.warning("dependencies_path is %s", dependencies_path)
+        LOG.warning("dist_dir is %s", dist_dir)
+        LOG.warning("build_cache_dir is %s", build_cache_dir)
         LOG.warning(
             "Build container started, waiting for completion (ID: %s)",
             container.short_id,
         )
         exit_code = yolo.build.wait_for_container_to_finish(container)
+        LOG.warning("exporting build cache...")
+        yolo.build.export_build_cache(build_volume_container, build_cache_dir)
+        LOG.warning("done exporting build cache.")
+        LOG.warning("exporting lambda zip...")
+        yolo.build.export_lambda_package(build_volume_container, dist_dir)
+        LOG.warning("done exporting lambda zip.")
         log_contents = container.logs(stdout=True, stderr=True)
         build_log.write(log_contents.decode('utf-8'))
         LOG.warning('Build log written to "%s"', build_log.name)
         yolo.build.remove_container(container)
+        # remove the container and its volumes
+        yolo.build.remove_container(build_volume_container, v=True)
         if exit_code != 0:
             raise Exception("Container exited with non-zero code.")
 


### PR DESCRIPTION
The dockerd supplied by CircleCI 2.0 is remote; this means we cannot use local filesystem `bind` mounts to supply the build cache and collect the resulting `lambda_function.zip`.

We have to create docker volumes and copy the build cache files & `lambda_function.zip` to/from them.